### PR TITLE
Se arreglo un error de fechas

### DIFF
--- a/src/route-sheets/dto/req/create-route-sheet.dto.ts
+++ b/src/route-sheets/dto/req/create-route-sheet.dto.ts
@@ -7,15 +7,15 @@ export class CreateRouteSheetDto {
   @IsNotEmpty()
   cooperativeId: number;
 
-  @ApiProperty({ description: 'Fecha de inicio de la hoja de ruta', type: String, format: 'date-time', example: '2025-06-15T00:00:00.000Z' })
-  @IsDateString()
+  @ApiProperty({ description: 'Fecha de inicio de la hoja de ruta', type: String, format: 'date-time', example: '2025-06-15' })
+  @IsString()
   @IsNotEmpty()
-  startDate: Date;
+  startDate: string;
 
-  @ApiProperty({ description: 'Fecha de fin de la hoja de ruta', type: String, format: 'date-time', example: '2025-06-25T00:00:00.000Z' })
-  @IsDateString()
+  @ApiProperty({ description: 'Fecha de fin de la hoja de ruta', type: String, format: 'date-time', example: '2025-06-25' })
+  @IsString()
   @IsNotEmpty()
-  endDate: Date;
+  endDate: string;
 
   @ApiProperty({ 
     description: 'IDs de las frecuencias que se incluirán en la hoja de ruta', 

--- a/src/route-sheets/route-sheets.service.ts
+++ b/src/route-sheets/route-sheets.service.ts
@@ -139,8 +139,8 @@ export class RouteSheetsService {
       const routeSheet = await tx.routeSheetHeader.create({
         data: {
           ...routeSheetData,
-          startDate,
-          endDate,
+          startDate: new Date(startDate),
+          endDate: new Date(endDate),
           status: routeSheetData.status || 'Pendiente',
         },
       });


### PR DESCRIPTION
This pull request updates the `CreateRouteSheetDto` and `RouteSheetsService` classes to change how date fields are handled. The most significant changes involve switching the `startDate` and `endDate` fields from `Date` to `string` in the DTO and ensuring proper conversion to `Date` objects in the service layer.

### Changes to date handling:

* [`src/route-sheets/dto/req/create-route-sheet.dto.ts`](diffhunk://#diff-5355484a89a6c67216ffc58e38b3ca07f71a4d402b274f897d4fee5eae67a4ecL10-R18): Updated the `startDate` and `endDate` fields in the `CreateRouteSheetDto` class to use `string` instead of `Date`. The validation decorators were changed from `@IsDateString()` to `@IsString()`, and the example format in `@ApiProperty` was updated accordingly.
* [`src/route-sheets/route-sheets.service.ts`](diffhunk://#diff-53a490ef39b32c0c89d0e77aa9f265947d7a6bfdf1b41476ebaefa3e5840ab6fL142-R143): Modified the `RouteSheetsService` class to convert the `startDate` and `endDate` fields from `string` to `Date` when creating a new route sheet in the database.